### PR TITLE
fix: 将生成的注册表文件改为 UTF-8 编码

### DIFF
--- a/src/installer.py
+++ b/src/installer.py
@@ -113,10 +113,10 @@ def generate_registry_file(obsidian_dir, exe_path):
 @="{exe_path_escaped} \\"%V\\""
 '''
     
-    # 写入注册表文件到当前目录
+    # 写入注册表文件到当前目录，使用UTF-8编码
     reg_file_path = os.path.join(os.getcwd(), "add_obsidian_context_menu.reg")
     try:
-        with open(reg_file_path, 'w', encoding='utf-16le') as f:
+        with open(reg_file_path, 'w', encoding='utf-8') as f:
             f.write(reg_content)
         print(f"注册表文件已生成: {reg_file_path}")
         return reg_file_path
@@ -141,7 +141,7 @@ def generate_uninstall_registry_file(current_dir):
     
     uninstall_reg_path = os.path.join(current_dir, "remove_obsidian_context_menu.reg")
     try:
-        with open(uninstall_reg_path, 'w', encoding='utf-16le') as f:
+        with open(uninstall_reg_path, 'w', encoding='utf-8') as f:
             f.write(uninstall_reg_content)
         print(f"卸载注册表文件已生成: {uninstall_reg_path}")
         return uninstall_reg_path


### PR DESCRIPTION
将 installer.py 中生成的注册表文件编码由 UTF-16LE 改为 UTF-8。
主要修改点：
- 写入 add_obsidian_context_menu.reg 时使用 encoding='utf-8'（原为 utf-16le）。
- 写入 remove_obsidian_context_menu.reg 时使用 encoding='utf-8'（原为 utf-16le）。
- 注释说明更新为“写入注册表文件到当前目录，使用UTF-8编码”。

原因：
- 使用 UTF-8 提高与现代工具和跨平台环境的兼容性，
  并避免部分文本编辑器或发布流程对 UTF-16LE 支持不佳导致的问题。