### PR TITLE
ci: 在构建流程中添加构建校验与改进打包日志

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,6 +49,29 @@ jobs:
         rm -rf build
         rm -f *.spec
         
+    - name: Verify build results
+      run: |
+        echo "=== 验证构建结果 ==="
+        echo "dist目录内容:"
+        ls -la dist/
+        echo ""
+        echo "检查exe文件是否存在:"
+        if [ -f "dist/open_folder_with_obsidian.exe" ]; then
+          echo "✓ open_folder_with_obsidian.exe 存在"
+        else
+          echo "✗ open_folder_with_obsidian.exe 不存在"
+          exit 1
+        fi
+        
+        if [ -f "dist/obsidian_installer.exe" ]; then
+          echo "✓ obsidian_installer.exe 存在"
+        else
+          echo "✗ obsidian_installer.exe 不存在"
+          exit 1
+        fi
+        
+        echo "构建验证完成"
+        
     - name: Create version info
       run: |
         # 创建版本信息文件到dist目录
@@ -70,10 +93,28 @@ jobs:
         
     - name: Create zip package
       run: |
-        # 创建zip包
+        echo "=== 创建zip包 ==="
         VERSION=$(echo $GITHUB_REF | sed 's/refs\/tags\///' || echo "dev")
+        echo "版本: $VERSION"
+        
         cd dist
-        zip -r "obsidian-folder-opener-${VERSION}.zip" *.exe *.md
+        echo "当前目录: $(pwd)"
+        echo "要打包的文件:"
+        ls -la *.exe *.md
+        
+        # 使用明确的文件路径创建zip包
+        zip -r "obsidian-folder-opener-${VERSION}.zip" \
+          "open_folder_with_obsidian.exe" \
+          "obsidian_installer.exe" \
+          "README.md"
+        
+        echo "zip包创建完成:"
+        ls -la *.zip
+        
+        # 验证zip包内容
+        echo "验证zip包内容:"
+        unzip -l "obsidian-folder-opener-${VERSION}.zip"
+        
         cd ..
         
     - name: Upload build artifacts


### PR DESCRIPTION
在 GitHub Actions 的 build-release 工作流中加入构建结果验证步骤，
确保 dist 目录下关键可执行文件存在（open_folder_with_obsidian.exe
和 obsidian_installer.exe），若缺失则中止流程，避免发布不完整产物。

增强打包步骤的可观测性：
- 输出版本号、当前目录和待打包文件列表，便于排查环境与文件问题。
- 使用明确的文件列表创建 zip 包（避免通配符误包含或遗漏）。
- 打印 zip 列表并列出生成的 zip 文件，进一步验证打包结果。

这些改动提升 CI 的可靠性与可调试性，尽早发现构建/打包异常。