### PR TITLE
ci: 将 CI 运行环境从 切换到 Windows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
GitHub Actions 中的构建作业运行器从
ubuntu-latest 改为 windows-latest，以在 Windows
环境下执行构建和测试。

原因：
- 需要在与目标部署或开发环境一致的 Windows
  平台上验证构建结果和相关工具行为。
- 修复了在 Ubuntu 环境中出现的平台相关差异或失败。